### PR TITLE
Add Bitcoin key generator demo

### DIFF
--- a/active-learning.html
+++ b/active-learning.html
@@ -37,6 +37,15 @@
           <a class="resource-link" href="https://icdi-blockchain-demo.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
         </div>
       </article>
+
+      <article class="resource-item">
+        <span class="resource-number">02</span>
+        <div>
+          <h2>ICDI Bitcoin Key Generator</h2>
+          <p>An interactive demonstration showing how a random 256-bit Bitcoin private key becomes uncompressed and compressed secp256k1 public keys.</p>
+          <a class="resource-link" href="https://icdi-key-generator-demo.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
+        </div>
+      </article>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed

Added the ICDI Bitcoin Key Generator to the Active Learning page, including a concise description and a link to the Streamlit demonstration.

## Why

This gives visitors a hands-on way to see how a random 256-bit Bitcoin private key maps to compressed and uncompressed secp256k1 public keys.

## Impact

The Active Learning page now lists a second interactive resource. No existing content or behavior was changed.

## Validation

- Confirmed the diff contains only the nine-line resource entry in `active-learning.html`
- Ran `git diff --check` successfully
