### PR TITLE
Add HD wallet demo

### DIFF
--- a/active-learning.html
+++ b/active-learning.html
@@ -46,6 +46,15 @@
           <a class="resource-link" href="https://icdi-key-generator-demo.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
         </div>
       </article>
+
+      <article class="resource-item">
+        <span class="resource-number">03</span>
+        <div>
+          <h2>ICDI HD Wallet Demo</h2>
+          <p>An interactive lab teaching how Bitcoin wallets transform entropy into BIP-39 mnemonics, seeds, BIP-32 HD keys, derivation paths, and Bitcoin addresses.</p>
+          <a class="resource-link" href="https://icdi-hd-wallet-demo.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
+        </div>
+      </article>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed

Added the ICDI HD Wallet Demo as the third resource on the Active Learning page, with a concise description and link to the Streamlit lab.

## Why

The lab helps visitors explore how Bitcoin wallets transform entropy into BIP-39 mnemonics, seeds, BIP-32 HD keys, derivation paths, and Bitcoin addresses.

## Impact

The Active Learning page now includes the HD Wallet learning resource. Existing resources and behavior remain unchanged.

## Validation

- Confirmed the clean checkout's `active-learning.html` exactly matches the local project file
- Confirmed the diff contains only the nine-line HD Wallet resource entry
- Ran `git diff --check` successfully
