### PR TITLE
Add Lightning payment simulation

### DIFF
--- a/active-learning.html
+++ b/active-learning.html
@@ -55,6 +55,15 @@
           <a class="resource-link" href="https://icdi-hd-wallet-demo.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
         </div>
       </article>
+
+      <article class="resource-item">
+        <span class="resource-number">04</span>
+        <div>
+          <h2>Lightning Network Payment Simulation</h2>
+          <p>An interactive simulation for experimenting with Lightning Network payment channels and seeing how payments move through the network.</p>
+          <a class="resource-link" href="https://lightning-network-test.streamlit.app/" target="_blank" rel="noreferrer">Open website ↗</a>
+        </div>
+      </article>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed

Added the Lightning Network Payment Simulation as the fourth resource on the Active Learning page, with a concise description and link to the Streamlit application.

## Why

The simulation lets visitors experiment with Lightning Network payment channels and observe how payments move through the network.

## Impact

The Active Learning page now includes the Lightning Network learning resource. Existing resources and behavior remain unchanged.

## Validation

- Confirmed the clean checkout's `active-learning.html` exactly matches the local project file
- Confirmed the diff contains only the nine-line Lightning resource entry
- Ran `git diff --check` successfully
